### PR TITLE
キャラ用のカメラと自動切り替え機能の追加。

### DIFF
--- a/Assets/Prefabs/BoardGame/CM vcam1_TopView.prefab
+++ b/Assets/Prefabs/BoardGame/CM vcam1_TopView.prefab
@@ -1,0 +1,142 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &7267510327848495699
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7267510327848495698}
+  - component: {fileID: 7267510327848495697}
+  m_Layer: 0
+  m_Name: CM vcam1_TopView
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7267510327848495698
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7267510327848495699}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -5.017747, y: 0.91922873, z: -0.037999842}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 1
+  m_Children:
+  - {fileID: 7267510328102537556}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &7267510327848495697
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7267510327848495699}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 45e653bab7fb20e499bda25e1b646fea, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_ExcludedPropertiesInInspector:
+  - m_Script
+  m_LockStageInInspector: 
+  m_StreamingVersion: 20170927
+  m_Priority: 10
+  m_StandbyUpdate: 2
+  m_LookAt: {fileID: 0}
+  m_Follow: {fileID: 0}
+  m_Lens:
+    FieldOfView: 60
+    OrthographicSize: 5
+    NearClipPlane: 0.3
+    FarClipPlane: 30
+    Dutch: 0
+    ModeOverride: 0
+    LensShift: {x: 0, y: 0}
+    GateFit: 2
+    m_SensorSize: {x: 2, y: 1}
+  m_Transitions:
+    m_BlendHint: 0
+    m_InheritPosition: 0
+    m_OnCameraLive:
+      m_PersistentCalls:
+        m_Calls: []
+  m_LegacyBlendHint: 0
+  m_ComponentOwner: {fileID: 7267510328102537556}
+--- !u!1 &7267510328102537557
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7267510328102537556}
+  - component: {fileID: 7267510328102537553}
+  - component: {fileID: 6507065294357308693}
+  m_Layer: 0
+  m_Name: cm
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7267510328102537556
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7267510328102537557}
+  m_LocalRotation: {x: -0.5596778, y: 0.0024861242, z: -0.001679048, w: 0.82870495}
+  m_LocalPosition: {x: -4.1773415, y: -0.1990757, z: 7.697509}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 1
+  m_Children: []
+  m_Father: {fileID: 7267510327848495698}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &7267510328102537553
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7267510328102537557}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ac0b09e7857660247b1477e93731de29, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &6507065294357308693
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7267510328102537557}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bd6043bde05a7fc4cba197d06915c1e3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Damping: {x: 0, y: 0, z: 0}
+  ShoulderOffset: {x: 0, y: 0.45, z: -1.15}
+  VerticalArmLength: 0.2
+  CameraSide: 0
+  CameraDistance: 0.38
+  CameraCollisionFilter:
+    serializedVersion: 2
+    m_Bits: 0
+  IgnoreTag: 
+  CameraRadius: 0.001
+  DampingIntoCollision: 0
+  DampingFromCollision: 0

--- a/Assets/Prefabs/BoardGame/CM vcam1_TopView.prefab.meta
+++ b/Assets/Prefabs/BoardGame/CM vcam1_TopView.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: bbc5de6615272f941b453f3b96480d8b
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/BoardGame.unity
+++ b/Assets/Scenes/BoardGame.unity
@@ -728,7 +728,7 @@ MonoBehaviour:
   cameraViews:
   - {fileID: 903746773}
   - {fileID: 0}
-  - {fileID: 255833906}
+  - {fileID: 0}
   viewNo: 0
   clearCamera: {fileID: 899640418}
 --- !u!4 &75940673
@@ -1596,77 +1596,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 7454705131206481506}
   m_PrefabAsset: {fileID: 0}
---- !u!1 &255833905
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 255833907}
-  - component: {fileID: 255833906}
-  m_Layer: 0
-  m_Name: CM vcam1_FrontView
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &255833906
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 255833905}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 45e653bab7fb20e499bda25e1b646fea, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_ExcludedPropertiesInInspector:
-  - m_Script
-  m_LockStageInInspector: 
-  m_StreamingVersion: 20170927
-  m_Priority: 5
-  m_StandbyUpdate: 2
-  m_LookAt: {fileID: 0}
-  m_Follow: {fileID: 255219629}
-  m_Lens:
-    FieldOfView: 60
-    OrthographicSize: 5
-    NearClipPlane: 0.3
-    FarClipPlane: 30
-    Dutch: 0
-    ModeOverride: 0
-    LensShift: {x: 0, y: 0}
-    GateFit: 2
-    m_SensorSize: {x: 2, y: 1}
-  m_Transitions:
-    m_BlendHint: 0
-    m_InheritPosition: 0
-    m_OnCameraLive:
-      m_PersistentCalls:
-        m_Calls: []
-  m_LegacyBlendHint: 0
-  m_ComponentOwner: {fileID: 1672127266}
---- !u!4 &255833907
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 255833905}
-  m_LocalRotation: {x: 0.2831772, y: -0.0028791614, z: 0.00085011404, w: 0.9590629}
-  m_LocalPosition: {x: -2.8495889, y: 5.431744, z: -8.396048}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 1
-  m_Children:
-  - {fileID: 1672127266}
-  m_Father: {fileID: 1990598541}
-  m_RootOrder: 3
-  m_LocalEulerAnglesHint: {x: 32.9, y: -0.344, z: 0}
 --- !u!1001 &291625493
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2008,7 +1937,7 @@ MonoBehaviour:
   m_BlendUpdateMethod: 1
   m_DefaultBlend:
     m_Style: 1
-    m_Time: 2
+    m_Time: 0.5
     m_CustomCurve:
       serializedVersion: 2
       m_Curve: []
@@ -5559,7 +5488,7 @@ Transform:
   m_Children:
   - {fileID: 1467962123}
   m_Father: {fileID: 1990598541}
-  m_RootOrder: 4
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: -4.22, y: 0, z: 0}
 --- !u!1 &900534815
 GameObject:
@@ -5653,7 +5582,7 @@ GameObject:
   - component: {fileID: 903746773}
   - component: {fileID: 903746775}
   m_Layer: 0
-  m_Name: CM vcam1
+  m_Name: CM vcam1_Player
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -6425,7 +6354,7 @@ PrefabInstance:
     - target: {fileID: 7267510327848495698, guid: bbc5de6615272f941b453f3b96480d8b,
         type: 3}
       propertyPath: m_RootOrder
-      value: 2
+      value: 4
       objectReference: {fileID: 0}
     - target: {fileID: 7267510327848495698, guid: bbc5de6615272f941b453f3b96480d8b,
         type: 3}
@@ -6834,6 +6763,54 @@ MonoBehaviour:
         m_Calls: []
   m_LegacyBlendHint: 0
   m_ComponentOwner: {fileID: 1865544881}
+--- !u!1 &1092259743
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1092259745}
+  - component: {fileID: 1092259744}
+  m_Layer: 0
+  m_Name: CameraManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1092259744
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1092259743}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bfc27d3153fdb5b43a4d785fe954615c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  virtualCameras:
+  - {fileID: 903746773}
+  - {fileID: 1428498341}
+  topViewCamera: {fileID: 2037113228}
+--- !u!4 &1092259745
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1092259743}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 1
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 32
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1111111489
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -8209,6 +8186,90 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1448095358}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &1428498338
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1428498339}
+  - component: {fileID: 1428498341}
+  - component: {fileID: 1428498340}
+  m_Layer: 0
+  m_Name: CM vcam1_Opponent
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1428498339
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1428498338}
+  m_LocalRotation: {x: 0.34657338, y: 0.38060063, z: -0.15648387, w: 0.84293705}
+  m_LocalPosition: {x: -6.0690713, y: 4.560369, z: -2.8603606}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 1
+  m_Children:
+  - {fileID: 1482717743}
+  m_Father: {fileID: 1990598541}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 44.7, y: 48.6, z: 0}
+--- !u!114 &1428498340
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1428498338}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 729aad4491e915a41bda2b8325cf757a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &1428498341
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1428498338}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 45e653bab7fb20e499bda25e1b646fea, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_ExcludedPropertiesInInspector:
+  - m_Script
+  m_LockStageInInspector: 
+  m_StreamingVersion: 20170927
+  m_Priority: 5
+  m_StandbyUpdate: 2
+  m_LookAt: {fileID: 0}
+  m_Follow: {fileID: 116256363}
+  m_Lens:
+    FieldOfView: 35
+    OrthographicSize: 5
+    NearClipPlane: 0.3
+    FarClipPlane: 30
+    Dutch: 0
+    ModeOverride: 0
+    LensShift: {x: 0, y: 0}
+    GateFit: 2
+    m_SensorSize: {x: 2, y: 1}
+  m_Transitions:
+    m_BlendHint: 0
+    m_InheritPosition: 0
+    m_OnCameraLive:
+      m_PersistentCalls:
+        m_Calls: []
+  m_LegacyBlendHint: 0
+  m_ComponentOwner: {fileID: 1482717743}
 --- !u!1001 &1431130725
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -9333,6 +9394,94 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 07144e1f351f24945bd8585090b27654, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1 &1482717742
+GameObject:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1482717743}
+  - component: {fileID: 1482717745}
+  - component: {fileID: 1482717744}
+  m_Layer: 0
+  m_Name: cm
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1482717743
+Transform:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1482717742}
+  m_LocalRotation: {x: -0.5596778, y: 0.0024861242, z: -0.001679048, w: 0.82870495}
+  m_LocalPosition: {x: -4.1773415, y: -0.1990757, z: 7.697509}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 1
+  m_Children: []
+  m_Father: {fileID: 1428498339}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1482717744
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1482717742}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6ad980451443d70438faac0bc6c235a0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_TrackedObjectOffset: {x: 0, y: 0, z: 0}
+  m_LookaheadTime: 0
+  m_LookaheadSmoothing: 0
+  m_LookaheadIgnoreY: 0
+  m_XDamping: 1
+  m_YDamping: 1
+  m_ZDamping: 1
+  m_TargetMovementOnly: 1
+  m_ScreenX: 0.5
+  m_ScreenY: 0.5
+  m_CameraDistance: 6
+  m_DeadZoneWidth: 0
+  m_DeadZoneHeight: 0
+  m_DeadZoneDepth: 0
+  m_UnlimitedSoftZone: 0
+  m_SoftZoneWidth: 0.3
+  m_SoftZoneHeight: 0.5
+  m_BiasX: 0
+  m_BiasY: 0
+  m_CenterOnActivate: 1
+  m_GroupFramingMode: 2
+  m_AdjustmentMode: 0
+  m_GroupFramingSize: 0.8
+  m_MaxDollyIn: 5000
+  m_MaxDollyOut: 5000
+  m_MinimumDistance: 1
+  m_MaximumDistance: 5000
+  m_MinimumFOV: 3
+  m_MaximumFOV: 60
+  m_MinimumOrthoSize: 1
+  m_MaximumOrthoSize: 5000
+--- !u!114 &1482717745
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1482717742}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ac0b09e7857660247b1477e93731de29, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &1496346294
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -9765,6 +9914,7 @@ MonoBehaviour:
   opponent: {fileID: 1728589174}
   eventChecker: {fileID: 959971177}
   gameStateModel: {fileID: 959971180}
+  cameraManager: {fileID: 1092259744}
 --- !u!114 &1542709113
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -10357,94 +10507,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   directionType: 4
   markerList: []
---- !u!1 &1672127265
-GameObject:
-  m_ObjectHideFlags: 3
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1672127266}
-  - component: {fileID: 1672127269}
-  - component: {fileID: 1672127270}
-  m_Layer: 0
-  m_Name: cm
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1672127266
-Transform:
-  m_ObjectHideFlags: 3
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1672127265}
-  m_LocalRotation: {x: -0.5596778, y: 0.0024861242, z: -0.001679048, w: 0.82870495}
-  m_LocalPosition: {x: -4.1773415, y: -0.1990757, z: 7.697509}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 1
-  m_Children: []
-  m_Father: {fileID: 255833907}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1672127269
-MonoBehaviour:
-  m_ObjectHideFlags: 3
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1672127265}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: ac0b09e7857660247b1477e93731de29, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &1672127270
-MonoBehaviour:
-  m_ObjectHideFlags: 3
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1672127265}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6ad980451443d70438faac0bc6c235a0, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_TrackedObjectOffset: {x: 0, y: 0, z: 0}
-  m_LookaheadTime: 0
-  m_LookaheadSmoothing: 0
-  m_LookaheadIgnoreY: 0
-  m_XDamping: 1
-  m_YDamping: 1
-  m_ZDamping: 1
-  m_TargetMovementOnly: 1
-  m_ScreenX: 0.5
-  m_ScreenY: 0.5
-  m_CameraDistance: 10
-  m_DeadZoneWidth: 0
-  m_DeadZoneHeight: 0
-  m_DeadZoneDepth: 0
-  m_UnlimitedSoftZone: 0
-  m_SoftZoneWidth: 0.8
-  m_SoftZoneHeight: 0.8
-  m_BiasX: 0
-  m_BiasY: 0
-  m_CenterOnActivate: 1
-  m_GroupFramingMode: 2
-  m_AdjustmentMode: 0
-  m_GroupFramingSize: 0.8
-  m_MaxDollyIn: 5000
-  m_MaxDollyOut: 5000
-  m_MinimumDistance: 1
-  m_MaximumDistance: 5000
-  m_MinimumFOV: 3
-  m_MaximumFOV: 60
-  m_MinimumOrthoSize: 1
-  m_MaximumOrthoSize: 5000
 --- !u!1001 &1683534306
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -12754,9 +12816,9 @@ Transform:
   m_Children:
   - {fileID: 330585546}
   - {fileID: 903746774}
-  - {fileID: 562805726}
-  - {fileID: 255833907}
+  - {fileID: 1428498339}
   - {fileID: 899640419}
+  - {fileID: 562805726}
   m_Father: {fileID: 0}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -13465,6 +13527,18 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 28
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &2037113228 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 7267510327848495697, guid: bbc5de6615272f941b453f3b96480d8b,
+    type: 3}
+  m_PrefabInstance: {fileID: 1059015732}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 45e653bab7fb20e499bda25e1b646fea, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &2082766894
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/BoardGame.unity
+++ b/Assets/Scenes/BoardGame.unity
@@ -5430,7 +5430,7 @@ GameObject:
   - component: {fileID: 899640419}
   - component: {fileID: 899640418}
   m_Layer: 0
-  m_Name: CM vcam1_ClearCamera
+  m_Name: CM vcam1_Isometric
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -5455,7 +5455,7 @@ MonoBehaviour:
   m_Priority: 5
   m_StandbyUpdate: 2
   m_LookAt: {fileID: 0}
-  m_Follow: {fileID: 255219629}
+  m_Follow: {fileID: 0}
   m_Lens:
     FieldOfView: 60
     OrthographicSize: 5
@@ -5481,15 +5481,15 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 899640417}
-  m_LocalRotation: {x: -0.036818076, y: 0, z: 0, w: 0.99932206}
-  m_LocalPosition: {x: -2.9, y: 0.52373374, z: -1.5634152}
+  m_LocalRotation: {x: 0.44148988, y: 0.25985497, z: -0.13527194, w: 0.84809417}
+  m_LocalPosition: {x: -3.53, y: 7.06, z: -1.51}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 1
   m_Children:
   - {fileID: 1467962123}
   m_Father: {fileID: 1990598541}
   m_RootOrder: 3
-  m_LocalEulerAnglesHint: {x: -4.22, y: 0, z: 0}
+  m_LocalEulerAnglesHint: {x: 55, y: 34.07, z: 0}
 --- !u!1 &900534815
 GameObject:
   m_ObjectHideFlags: 0
@@ -9070,7 +9070,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 6ad980451443d70438faac0bc6c235a0, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_TrackedObjectOffset: {x: -0.0123012345, y: 0.64, z: 0}
+  m_TrackedObjectOffset: {x: 5.07475, y: 2.2653472, z: -0.100323014}
   m_LookaheadTime: 0
   m_LookaheadSmoothing: 0
   m_LookaheadIgnoreY: 0
@@ -9080,7 +9080,7 @@ MonoBehaviour:
   m_TargetMovementOnly: 1
   m_ScreenX: 0.5
   m_ScreenY: 0.5
-  m_CameraDistance: 1.58
+  m_CameraDistance: 0.01
   m_DeadZoneWidth: 0
   m_DeadZoneHeight: 0
   m_DeadZoneDepth: 0
@@ -14310,6 +14310,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Enabled
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4898273226773844237, guid: 821ac4ecef6f2c440a9148e825c17574,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -12.21
       objectReference: {fileID: 0}
     - target: {fileID: 7494743041402614142, guid: 821ac4ecef6f2c440a9148e825c17574,
         type: 3}

--- a/Assets/Scenes/BoardGame.unity
+++ b/Assets/Scenes/BoardGame.unity
@@ -5651,6 +5651,7 @@ GameObject:
   m_Component:
   - component: {fileID: 903746774}
   - component: {fileID: 903746773}
+  - component: {fileID: 903746775}
   m_Layer: 0
   m_Name: CM vcam1
   m_TagString: Untagged
@@ -5712,6 +5713,18 @@ Transform:
   m_Father: {fileID: 1990598541}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 44.7, y: 48.6, z: 0}
+--- !u!114 &903746775
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 903746772}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 729aad4491e915a41bda2b8325cf757a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &915771152
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -6247,6 +6260,7 @@ GameObject:
   - component: {fileID: 959971179}
   - component: {fileID: 959971177}
   - component: {fileID: 959971178}
+  - component: {fileID: 959971180}
   m_Layer: 0
   m_Name: EventChecker
   m_TagString: Untagged
@@ -6299,6 +6313,20 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 29
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &959971180
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 959971176}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3f92dbc5abf343a448f899021a3323af, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  CurrentGameState:
+    value: 0
 --- !u!1 &1001991032
 GameObject:
   m_ObjectHideFlags: 0
@@ -6314,7 +6342,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 2147483647
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &1001991033
 Transform:
   m_ObjectHideFlags: 0
@@ -6323,7 +6351,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1001991032}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 9, y: 0, z: 0}
+  m_LocalPosition: {x: 2.17, y: -14.28, z: 21.19}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 1
   m_Children:
@@ -9736,6 +9764,7 @@ MonoBehaviour:
   player: {fileID: 841157373}
   opponent: {fileID: 1728589174}
   eventChecker: {fileID: 959971177}
+  gameStateModel: {fileID: 959971180}
 --- !u!114 &1542709113
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -12491,6 +12520,104 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1111111489}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &1919671483
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1919671487}
+  - component: {fileID: 1919671486}
+  - component: {fileID: 1919671485}
+  - component: {fileID: 1919671484}
+  m_Layer: 0
+  m_Name: Quad
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!64 &1919671484
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1919671483}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 4
+  m_Convex: 0
+  m_CookingOptions: 30
+  m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &1919671485
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1919671483}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a59f5ea798ef98649990d08a4a4d2f57, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &1919671486
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1919671483}
+  m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &1919671487
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1919671483}
+  m_LocalRotation: {x: 0.7071068, y: 0, z: 0, w: 0.7071068}
+  m_LocalPosition: {x: -0.8227, y: -6.61, z: 0.8096}
+  m_LocalScale: {x: 25.422857, y: 26.486687, z: 15}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 31
+  m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}
 --- !u!4 &1949892392 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 5912604511481158432, guid: f01aa3b693790394a923bc085106a8cb,

--- a/Assets/Scripts/BoardGame/Camera.meta
+++ b/Assets/Scripts/BoardGame/Camera.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 834634acaf728434fa3dbab657387a35
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/BoardGame/Camera/CameraManager.cs
+++ b/Assets/Scripts/BoardGame/Camera/CameraManager.cs
@@ -1,0 +1,25 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using Cinemachine;
+
+public class CameraManager : MonoBehaviour
+{
+    [SerializeField]
+    CinemachineVirtualCamera[] virtualCameras;
+
+    [SerializeField]
+    CinemachineVirtualCamera topViewCamera;
+
+
+    /// <summary>
+    /// ƒLƒƒƒ‰ƒJƒƒ‰‚ÌØ‚è‘Ö‚¦
+    /// </summary>
+    /// <param name="index"></param>
+    public void SwitchCharaCamera(int index) {
+
+        for (int i = 0; i < virtualCameras.Length; i++) {
+            virtualCameras[i].Priority = index == i ? 10 : 5;
+        }
+    }
+}

--- a/Assets/Scripts/BoardGame/Camera/CameraManager.cs.meta
+++ b/Assets/Scripts/BoardGame/Camera/CameraManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bfc27d3153fdb5b43a4d785fe954615c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/BoardGame/DiceRoll/DiceRollPresenter.cs
+++ b/Assets/Scripts/BoardGame/DiceRoll/DiceRollPresenter.cs
@@ -34,6 +34,9 @@ namespace yamap_BoardGame {
         [SerializeField]
         private GameStateModel gameStateModel;
 
+        [SerializeField]
+        private CameraManager cameraManager;
+
 
         private DiceRollObserver diceRollObserver;
 
@@ -70,11 +73,13 @@ namespace yamap_BoardGame {
                     await eventChecker.CheckEventAsync(player.Chara, movedStopPanel);
 
                     await UniTask.Delay(500, cancellationToken: token);
-                    player.Chara.IsMyTurn.Value = false;
-                                    
+                    
+
                     //Debug.Log("opponent.Chara.IsMyTurn.Value : " + opponent.Chara.IsMyTurn.Value);
                     // ÉJÉÅÉâ
-
+                    cameraManager.SwitchCharaCamera((int)opponent.Chara.ownerType);
+                    await UniTask.Delay(250, cancellationToken: token);
+                    player.Chara.IsMyTurn.Value = false;
                 })
                 .AddTo(this);
 
@@ -88,10 +93,12 @@ namespace yamap_BoardGame {
                     await eventChecker.CheckEventAsync(opponent.Chara, movedStopPanel);
 
                     await UniTask.Delay(500, cancellationToken: token);
-                    opponent.Chara.IsMyTurn.Value = false;
+                    
 
                     // ÉJÉÅÉâ
-                    
+                    cameraManager.SwitchCharaCamera((int)player.Chara.ownerType);
+                    await UniTask.Delay(250, cancellationToken: token);
+                    opponent.Chara.IsMyTurn.Value = false;
                 })
                 .AddTo(this);
 


### PR DESCRIPTION
・キャラ用の Cinemachine をキャラ数だけ追加。設定調整。
・CameraManager.cs 作成。

・Presenter を修正し、移動するキャラに合わせて自動的にカメラが切り替わる機能を追加。
　カメラの切り替え速度を調整。

・デバッグ完了。