### PR TITLE
アイテム発掘、ペナルティのルールを追加。

### DIFF
--- a/Assets/Scenes/BoardGame.unity
+++ b/Assets/Scenes/BoardGame.unity
@@ -1458,6 +1458,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   directionType: 4
   markerList: []
+  itemIds: 000000000100000002000000030000000400000005000000
 --- !u!4 &222081076 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 3978516833511601658, guid: 1f9592db56cb8bf4abbbbc6c1ef0a038,
@@ -1584,6 +1585,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   directionType: 4
   markerList: []
+  itemIds: 000000000100000002000000030000000400000005000000
 --- !u!1 &254921613 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 7454705131392196079, guid: ef1e0bb6218332a40987596cfc0529aa,
@@ -2447,6 +2449,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   directionType: 4
   markerList: []
+  itemIds: 000000000100000002000000030000000400000005000000
 --- !u!1001 &386157686
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2567,6 +2570,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   directionType: 4
   markerList: []
+  itemIds: 000000000100000002000000030000000400000005000000
 --- !u!4 &409058193 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 6746730152220112068, guid: 6aee1144b641c344eaef46e99efc6d5d,
@@ -2944,6 +2948,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   directionType: 4
   markerList: []
+  itemIds: 000000000100000002000000030000000400000005000000
 --- !u!1 &471858559
 GameObject:
   m_ObjectHideFlags: 0
@@ -3712,6 +3717,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   directionType: 3
   markerList: []
+  itemIds: 000000000100000002000000030000000400000005000000
 --- !u!1001 &556253109
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -3832,6 +3838,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   directionType: 4
   markerList: []
+  itemIds: 000000000100000002000000030000000400000005000000
 --- !u!4 &562805726 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 7267510327848495698, guid: bbc5de6615272f941b453f3b96480d8b,
@@ -4595,6 +4602,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   directionType: 4
   markerList: []
+  itemIds: 000000000100000002000000030000000400000005000000
 --- !u!1001 &778635485
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -4883,6 +4891,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   directionType: 1
   markerList: []
+  itemIds: 000000000100000002000000030000000400000005000000
 --- !u!4 &865473751 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 5912604511481158432, guid: f01aa3b693790394a923bc085106a8cb,
@@ -5774,6 +5783,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   directionType: 4
   markerList: []
+  itemIds: 000000000100000002000000030000000400000005000000
 --- !u!1001 &928811050
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -5989,6 +5999,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   directionType: 4
   markerList: []
+  itemIds: 000000000100000002000000030000000400000005000000
 --- !u!1001 &946090245
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -7135,6 +7146,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   directionType: 2
   markerList: []
+  itemIds: 000000000100000002000000030000000400000005000000
 --- !u!4 &1181002029 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 3978516833511601658, guid: 1f9592db56cb8bf4abbbbc6c1ef0a038,
@@ -7461,6 +7473,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   directionType: 4
   markerList: []
+  itemIds: 000000000100000002000000030000000400000005000000
 --- !u!1001 &1239848556
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -9691,6 +9704,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   directionType: 4
   markerList: []
+  itemIds: 000000000100000002000000030000000400000005000000
 --- !u!1 &1515514908
 GameObject:
   m_ObjectHideFlags: 0
@@ -9843,6 +9857,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   directionType: 4
   markerList: []
+  itemIds: 000000000100000002000000030000000400000005000000
 --- !u!1 &1524144639 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 4862891238472894586, guid: 5813fef60ff72cf43a30a3b9cf83ee7f,
@@ -10507,6 +10522,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   directionType: 4
   markerList: []
+  itemIds: 000000000100000002000000030000000400000005000000
 --- !u!1001 &1683534306
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -10833,6 +10849,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   directionType: 0
   markerList: []
+  itemIds: 000000000100000002000000030000000400000005000000
 --- !u!1001 &1728589170
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -11511,6 +11528,53 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d186479fd7a3bdc44b7479c7cfec96e7, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1 &1795933468
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1795933470}
+  - component: {fileID: 1795933469}
+  m_Layer: 0
+  m_Name: ItemManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1795933469
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1795933468}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0a73bdfe60ecc074a924f681f9583441, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  playerItemList: []
+  opponentItemList: []
+  itemDataSO: {fileID: 11400000, guid: b84b52e32df02d64c8ac06bf8eb1d7f6, type: 2}
+--- !u!4 &1795933470
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1795933468}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 1
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 33
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1800412671
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -12147,6 +12211,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   directionType: 4
   markerList: []
+  itemIds: 000000000100000002000000030000000400000005000000
 --- !u!1 &1865544880
 GameObject:
   m_ObjectHideFlags: 3
@@ -12942,6 +13007,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   directionType: 4
   markerList: []
+  itemIds: 000000000100000002000000030000000400000005000000
 --- !u!4 &2002000066 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 6746730152220112068, guid: 6aee1144b641c344eaef46e99efc6d5d,
@@ -13341,6 +13407,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   directionType: 4
   markerList: []
+  itemIds: 000000000100000002000000030000000400000005000000
 --- !u!1001 &2034894610
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/BoardGame/CharaMove/Panel.cs
+++ b/Assets/Scripts/BoardGame/CharaMove/Panel.cs
@@ -16,5 +16,22 @@ namespace yamap_BoardGame {
 
         // 陣地
         public List<Marker> markerList = new();
+
+        public int[] itemIds;
+
+        /// <summary>
+        /// すべてのマーカーを取り除く
+        /// </summary>
+        public void RemoveMarkers() {
+            for (int i = 0; i < markerList.Count; i++) {
+                Destroy(markerList[i].gameObject);
+            }
+            markerList.Clear();
+        }
+
+
+        public int GetRandomItemIds() {
+            return itemIds[Random.Range(0, itemIds.Length)];
+        }
     }
 }

--- a/Assets/Scripts/BoardGame/Event/EventChecker.cs
+++ b/Assets/Scripts/BoardGame/Event/EventChecker.cs
@@ -20,6 +20,7 @@ namespace yamap_BoardGame {
             if (panel.markerList.Count == 0) {
                 panel.markerList.Add(markerFactory.GenerateMarker(chara.ownerType, panel, panel.markerList.Count));
                 Debug.Log("新規作成");
+                ItemManager.instance.AddItem(chara.ownerType, panel.GetRandomItemIds());
                 return;
             } 
                 
@@ -28,6 +29,7 @@ namespace yamap_BoardGame {
                 // 増産
                 panel.markerList.Add(markerFactory.GenerateMarker(chara.ownerType, panel, panel.markerList.Count));
                 Debug.Log("増産");
+                ItemManager.instance.AddItem(chara.ownerType, panel.GetRandomItemIds());
                 return;
             }
 
@@ -35,6 +37,12 @@ namespace yamap_BoardGame {
             chara.Hp.Value -= panel.markerList.Count;
             Debug.Log(chara.ownerType + " 残りHP : " + chara.Hp.Value);
 
+            // アイテムをランダムで破棄
+            ItemManager.instance.RemoveItems(chara.ownerType, panel.markerList.Count);
+
+            // マーカーを破棄
+            panel.RemoveMarkers();
+            
             await UniTask.Yield();
         }
     }

--- a/Assets/Scripts/BoardGame/Item.meta
+++ b/Assets/Scripts/BoardGame/Item.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: eaea3ae989e51c4468ade688fac1d75f
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/BoardGame/Item/Item.cs
+++ b/Assets/Scripts/BoardGame/Item/Item.cs
@@ -1,0 +1,18 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class Item : MonoBehaviour
+{
+    // Start is called before the first frame update
+    void Start()
+    {
+        
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        
+    }
+}

--- a/Assets/Scripts/BoardGame/Item/Item.cs.meta
+++ b/Assets/Scripts/BoardGame/Item/Item.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fbf9e2ac732d0db4aa20d129fc84124d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/BoardGame/Item/ItemData.cs
+++ b/Assets/Scripts/BoardGame/Item/ItemData.cs
@@ -1,0 +1,12 @@
+using UnityEngine;
+
+namespace yamap_BoardGame {
+
+    [System.Serializable]
+    public class ItemData {
+        public int id;
+        public string name;
+        public Sprite sprite;
+        public int score;
+    }
+}

--- a/Assets/Scripts/BoardGame/Item/ItemData.cs.meta
+++ b/Assets/Scripts/BoardGame/Item/ItemData.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7930d5da8331b174785ee63e8f49441c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/BoardGame/Item/ItemDataSO.asset
+++ b/Assets/Scripts/BoardGame/Item/ItemDataSO.asset
@@ -1,0 +1,39 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 31ae4df663ee32b4d86b205e6a41083b, type: 3}
+  m_Name: ItemDataSO
+  m_EditorClassIdentifier: 
+  itemDataList:
+  - id: 0
+    name: AA
+    sprite: {fileID: 0}
+    score: 10
+  - id: 1
+    name: BB
+    sprite: {fileID: 0}
+    score: 20
+  - id: 2
+    name: CC
+    sprite: {fileID: 0}
+    score: 30
+  - id: 3
+    name: DD
+    sprite: {fileID: 0}
+    score: 50
+  - id: 4
+    name: EE
+    sprite: {fileID: 0}
+    score: 70
+  - id: 5
+    name: FF
+    sprite: {fileID: 0}
+    score: 100

--- a/Assets/Scripts/BoardGame/Item/ItemDataSO.asset.meta
+++ b/Assets/Scripts/BoardGame/Item/ItemDataSO.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b84b52e32df02d64c8ac06bf8eb1d7f6
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/BoardGame/Item/ItemDataSO.cs
+++ b/Assets/Scripts/BoardGame/Item/ItemDataSO.cs
@@ -1,0 +1,11 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace yamap_BoardGame {
+
+    [CreateAssetMenu(fileName = "ItemDataSO", menuName = "Create ItemDataSO")]
+    public class ItemDataSO : ScriptableObject {
+        public List<ItemData> itemDataList = new();
+    }
+}

--- a/Assets/Scripts/BoardGame/Item/ItemDataSO.cs.meta
+++ b/Assets/Scripts/BoardGame/Item/ItemDataSO.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 31ae4df663ee32b4d86b205e6a41083b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/BoardGame/Item/ItemManager.cs
+++ b/Assets/Scripts/BoardGame/Item/ItemManager.cs
@@ -1,0 +1,57 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace yamap_BoardGame {
+
+    public class ItemManager : MonoBehaviour {
+
+        public static ItemManager instance;
+
+        public List<ItemData> playerItemList = new();
+        public List<ItemData> opponentItemList = new();  // ReactiveCollection ‚É‚µ‚Ä‚à‚¢‚¢
+
+        public ItemDataSO itemDataSO;
+
+
+        void Awake() {
+            if (instance == null) {
+                instance = this;
+                DontDestroyOnLoad(gameObject);
+            } else {
+                Destroy(gameObject);
+            }
+        }
+
+
+        public void AddItem(OwnerType ownerType, int itemId) {
+            if (ownerType == OwnerType.Player) {
+                playerItemList.Add(GetItemDataFromId(itemId));
+            } else {
+                opponentItemList.Add(GetItemDataFromId(itemId));
+            }
+        }
+
+        public ItemData GetItemDataFromId(int id) {
+            return itemDataSO.itemDataList.Find(x => x.id == id);
+        }
+
+
+        public void RemoveItems(OwnerType ownerType, int count) {
+
+            // Å‘å”‚ğ’´‚¦‚È‚¢‚æ‚¤‚É§ŒÀ
+            if (ownerType == OwnerType.Player) {
+                count = Mathf.Max(0, playerItemList.Count);
+
+                for (int i = 0; i < count; i++) {
+                    playerItemList.Remove(playerItemList[i]);
+                }
+            } else {
+                count = Mathf.Max(0, opponentItemList.Count);
+                for (int i = 0; i < count; i++) {
+                    opponentItemList.Remove(opponentItemList[i]);
+                }
+            }      
+        }
+    }
+}

--- a/Assets/Scripts/BoardGame/Item/ItemManager.cs
+++ b/Assets/Scripts/BoardGame/Item/ItemManager.cs
@@ -41,15 +41,21 @@ namespace yamap_BoardGame {
 
             // ç≈ëÂêîÇí¥Ç¶Ç»Ç¢ÇÊÇ§Ç…êßå¿
             if (ownerType == OwnerType.Player) {
-                count = Mathf.Max(0, playerItemList.Count);
+                count = Mathf.Min(count, playerItemList.Count);
 
-                for (int i = 0; i < count; i++) {
-                    playerItemList.Remove(playerItemList[i]);
+                for (int i = count - 1; i >= 0; i--) {
+                    playerItemList.RemoveAt(i);
                 }
+
+                //for (int i = list.Count - 1; i >= 0; i--) {
+                //    if (list[i].Taste == Taste.Bad) {
+                //        list.RemoveAt(i); // Remove(list[i])ÇÕégÇÌÇ»Ç¢éñÅB
+                //    }
+                //}
             } else {
-                count = Mathf.Max(0, opponentItemList.Count);
-                for (int i = 0; i < count; i++) {
-                    opponentItemList.Remove(opponentItemList[i]);
+                count = Mathf.Min(count, opponentItemList.Count);
+                for (int i = count - 1; i >= 0; i--) {
+                    opponentItemList.RemoveAt(i);
                 }
             }      
         }

--- a/Assets/Scripts/BoardGame/Item/ItemManager.cs.meta
+++ b/Assets/Scripts/BoardGame/Item/ItemManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0a73bdfe60ecc074a924f681f9583441
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VisualScriptingTutorial/CompleteGame/Models/Environment/Floor2_New.FBX.meta
+++ b/Assets/VisualScriptingTutorial/CompleteGame/Models/Environment/Floor2_New.FBX.meta
@@ -1,7 +1,7 @@
 fileFormatVersion: 2
 guid: 5eb36bc7e931a0e46a09c8b4720a81da
 ModelImporter:
-  serializedVersion: 21100
+  serializedVersion: 21202
   internalIDToNameTable: []
   externalObjects:
   - first:
@@ -19,6 +19,7 @@ ModelImporter:
     bakeSimulation: 0
     resampleCurves: 1
     optimizeGameObjects: 0
+    removeConstantScaleCurves: 0
     motionNodeName: 
     rigImportErrors: 
     rigImportWarnings: 
@@ -36,7 +37,7 @@ ModelImporter:
     extraExposedTransformPaths: []
     extraUserProperties: []
     clipAnimations: []
-    isReadable: 0
+    isReadable: 1
   meshes:
     lODScreenPercentages: []
     globalScale: 1
@@ -48,6 +49,7 @@ ModelImporter:
     importBlendShapes: 1
     importCameras: 1
     importLights: 1
+    nodeNameCollisionStrategy: 0
     fileIdsGeneration: 2
     swapUVChannels: 0
     generateSecondaryUV: 0
@@ -59,6 +61,7 @@ ModelImporter:
     skinWeightsMode: 0
     maxBonesPerVertex: 4
     minBoneWeight: 0.001
+    optimizeBones: 1
     meshOptimizationFlags: -1
     indexFormat: 0
     secondaryUVAngleDistortion: 8

--- a/UserSettings/Layouts/default-2021.dwlt
+++ b/UserSettings/Layouts/default-2021.dwlt
@@ -74,7 +74,7 @@ MonoBehaviour:
   m_MinSize: {x: 100, y: 200}
   m_MaxSize: {x: 8096, y: 16192}
   vertical: 1
-  controlID: 35
+  controlID: 26
 --- !u!114 &4
 MonoBehaviour:
   m_ObjectHideFlags: 52
@@ -94,8 +94,8 @@ MonoBehaviour:
     y: 995.3333
     width: 674.6666
     height: 312.00006
-  m_MinSize: {x: 100, y: 100}
-  m_MaxSize: {x: 4000, y: 4000}
+  m_MinSize: {x: 101, y: 121}
+  m_MaxSize: {x: 4001, y: 4021}
   m_ActualView: {fileID: 26}
   m_Panes:
   - {fileID: 26}
@@ -125,7 +125,7 @@ MonoBehaviour:
   m_MinSize: {x: 100, y: 200}
   m_MaxSize: {x: 8096, y: 16192}
   vertical: 1
-  controlID: 159
+  controlID: 179
 --- !u!114 &6
 MonoBehaviour:
   m_ObjectHideFlags: 52
@@ -176,7 +176,7 @@ MonoBehaviour:
   m_MinSize: {x: 100, y: 200}
   m_MaxSize: {x: 8096, y: 16192}
   vertical: 1
-  controlID: 102
+  controlID: 122
 --- !u!114 &8
 MonoBehaviour:
   m_ObjectHideFlags: 52
@@ -227,7 +227,7 @@ MonoBehaviour:
   m_MinSize: {x: 300, y: 200}
   m_MaxSize: {x: 24288, y: 16192}
   vertical: 0
-  controlID: 158
+  controlID: 178
 --- !u!114 &10
 MonoBehaviour:
   m_ObjectHideFlags: 52
@@ -247,8 +247,8 @@ MonoBehaviour:
     y: 0
     width: 674.6666
     height: 995.3333
-  m_MinSize: {x: 275, y: 50}
-  m_MaxSize: {x: 4000, y: 4000}
+  m_MinSize: {x: 276, y: 71}
+  m_MaxSize: {x: 4001, y: 4021}
   m_ActualView: {fileID: 22}
   m_Panes:
   - {fileID: 22}
@@ -350,7 +350,7 @@ MonoBehaviour:
   m_MinSize: {x: 200, y: 200}
   m_MaxSize: {x: 16192, y: 16192}
   vertical: 0
-  controlID: 34
+  controlID: 25
 --- !u!114 &15
 MonoBehaviour:
   m_ObjectHideFlags: 52
@@ -380,7 +380,7 @@ MonoBehaviour:
   - {fileID: 17}
   - {fileID: 16}
   m_Selected: 0
-  m_LastSelected: 3
+  m_LastSelected: 2
 --- !u!114 &16
 MonoBehaviour:
   m_ObjectHideFlags: 52
@@ -805,22 +805,22 @@ MonoBehaviour:
     m_SkipHidden: 0
     m_SearchArea: 1
     m_Folders:
-    - Assets/Prefabs/BoardGame
+    - Assets/Scripts/BoardGame/Camera
     m_Globs: []
     m_OriginalText: 
   m_ViewMode: 1
   m_StartGridSize: 16
   m_LastFolders:
-  - Assets/Prefabs/BoardGame
+  - Assets/Scripts/BoardGame/Camera
   m_LastFoldersGridSize: 16
   m_LastProjectPath: C:\Users\komay\Documents\InductionGame
   m_LockTracker:
     m_IsLocked: 0
   m_FolderTreeState:
-    scrollPos: {x: 0, y: 81.666626}
-    m_SelectedIDs: 68780000
-    m_LastClickedID: 30824
-    m_ExpandedIDs: 0000000056760000587600005a7600005c7600005e76000060760000627600006476000066760000687600006a7600006c7600006e760000707600007276000074760000787600006278000000ca9a3bffffff7f
+    scrollPos: {x: 0, y: 0}
+    m_SelectedIDs: 5cb00000
+    m_LastClickedID: 45148
+    m_ExpandedIDs: 000000005e77000060770000627700006477000066770000687700006a7700006c7700006e77000070770000727700007477000076770000787700007a7700007c7700007e770000807700007279000090790000ec87000000ca9a3bffffff7f
     m_RenameOverlay:
       m_UserAcceptedRename: 0
       m_Name: 
@@ -848,7 +848,7 @@ MonoBehaviour:
     scrollPos: {x: 0, y: 0}
     m_SelectedIDs: 
     m_LastClickedID: 0
-    m_ExpandedIDs: 0000000056760000587600005a7600005c7600005e76000060760000627600006476000066760000687600006a7600006c7600006e7600007076000072760000747600007676000078760000
+    m_ExpandedIDs: 000000005e77000060770000627700006477000066770000687700006a7700006c7700006e77000070770000727700007477000076770000787700007a7700007c7700007e77000080770000
     m_RenameOverlay:
       m_UserAcceptedRename: 0
       m_Name: 
@@ -879,18 +879,18 @@ MonoBehaviour:
     m_ExpandedInstanceIDs: c6230000866b0000a46b000000000000d06900001c7c0000f06c000038caffff5ad2ffff467200004a720000
     m_RenameOverlay:
       m_UserAcceptedRename: 0
-      m_Name: 
-      m_OriginalName: 
+      m_Name: CameraManager
+      m_OriginalName: CameraManager
       m_EditFieldRect:
         serializedVersion: 2
         x: 0
         y: 0
         width: 0
         height: 0
-      m_UserData: 0
+      m_UserData: 45152
       m_IsWaitingForDelay: 0
       m_IsRenaming: 0
-      m_OriginalEventType: 11
+      m_OriginalEventType: 0
       m_IsRenamingFilename: 1
       m_ClientGUIView: {fileID: 6}
     m_CreateAssetUtility:
@@ -977,10 +977,10 @@ MonoBehaviour:
     m_SaveData: []
   m_SceneHierarchy:
     m_TreeViewState:
-      scrollPos: {x: 0, y: 102}
-      m_SelectedIDs: 44bb0100
-      m_LastClickedID: 113476
-      m_ExpandedIDs: 3af9feff44f9feffea03ffff7405ffff16d2ffff16fbfffff4fffffff08500004cb80100ecb8010020b90100f8b9010024bb010044bb010050bb0100
+      scrollPos: {x: 0, y: 0}
+      m_SelectedIDs: 926f0000
+      m_LastClickedID: 28562
+      m_ExpandedIDs: 0a65feffdceeffffe6eeffff16fbffff486e0000f46f00004c710000
       m_RenameOverlay:
         m_UserAcceptedRename: 0
         m_Name: 
@@ -996,7 +996,7 @@ MonoBehaviour:
         m_IsRenaming: 0
         m_OriginalEventType: 11
         m_IsRenamingFilename: 0
-        m_ClientGUIView: {fileID: 8}
+        m_ClientGUIView: {fileID: 15}
       m_SearchString: 
     m_ExpandedScenes: []
     m_CurrenRootInstanceID: 0
@@ -1281,11 +1281,11 @@ MonoBehaviour:
   m_Rotation:
     m_Target: {x: 0.42177644, y: 0.28958616, z: -0.14418803, w: 0.8470335}
     speed: 2
-    m_Value: {x: 0.42536265, y: 0.29020008, z: -0.14612712, w: 0.84468776}
+    m_Value: {x: 0.42177403, y: 0.2895845, z: -0.14418721, w: 0.8470287}
   m_Size:
-    m_Target: 5.523156
+    m_Target: 14.551183
     speed: 2
-    m_Value: 5.067116
+    m_Value: 14.551183
   m_Ortho:
     m_Target: 1
     speed: 2


### PR DESCRIPTION
・ItemData.cs、ItemDataSO.cs、ItemManager.cs 作成。
・Panel.cs、EventChecker.cs 修正。停止したパネルにおいてランダムなアイテムを取得(発掘)する機能を追加。
　相手側のマーカーがある場合には発掘せず、所持しているアイテムをマーカー数だけ削除する機能を追加。

・アイテムの削除処理の修正。内部処理問題なし。
・デバッグ完了。画面反映はまだ。